### PR TITLE
Fix wrong child representation returned by toTree

### DIFF
--- a/src/toTree.js
+++ b/src/toTree.js
@@ -24,6 +24,11 @@ function childrenToTree(node) {
     return node.children.map(toTree);
   }
 
+  if (node.children.flags & VNodeFlags.Text) {
+    const tree = toTree(node.children);
+    return tree ? [tree] : tree;
+  }
+
   return toTree(node.children);
 }
 

--- a/test/specs/Adapter.spec.js
+++ b/test/specs/Adapter.spec.js
@@ -184,7 +184,7 @@ describe('adapter', () => {
           key: null,
           ref: null,
           instance: null,
-          rendered: 'Hello World!',
+          rendered: ['Hello World!'],
         },
       }));
     });
@@ -221,7 +221,7 @@ describe('adapter', () => {
           key: null,
           ref: null,
           instance: null,
-          rendered: 'Hello World!',
+          rendered: ['Hello World!'],
         },
       }));
     });
@@ -340,7 +340,7 @@ describe('adapter', () => {
                   key: '$0',
                   ref: null,
                   instance: null,
-                  rendered: 'Literal',
+                  rendered: ['Literal'],
                 },
                 {
                   nodeType: 'function',
@@ -356,7 +356,7 @@ describe('adapter', () => {
                     key: null,
                     ref: null,
                     instance: null,
-                    rendered: 'Hello World!',
+                    rendered: ['Hello World!'],
                   },
                 },
               ],
@@ -460,7 +460,7 @@ describe('adapter', () => {
                   key: '$0',
                   ref: null,
                   instance: null,
-                  rendered: 'Literal',
+                  rendered: ['Literal'],
                 },
                 {
                   nodeType: 'class',
@@ -476,7 +476,7 @@ describe('adapter', () => {
                     key: null,
                     ref: null,
                     instance: null,
-                    rendered: 'Hello World!',
+                    rendered: ['Hello World!'],
                   },
                 },
               ],


### PR DESCRIPTION
After checking if there are multiple children (array of children should stay flat)
check if the child is a wrapper for Text Node.
If it is parse the child text node and wrap it in an array (but only if a valid child is returned).

Includes fix of test for master: due to merge